### PR TITLE
Env var fixes

### DIFF
--- a/src/Elders.Pandora/ApplicationContext.cs
+++ b/src/Elders.Pandora/ApplicationContext.cs
@@ -2,11 +2,6 @@ using System;
 
 namespace Elders.Pandora
 {
-    public static class EnvVar
-    {
-        public const string ClusterKey = "CLUSTER_NAME";
-        public const string MachineKey = "COMPUTERNAME";
-    }
 
     public interface IPandoraContext
     {
@@ -19,11 +14,11 @@ namespace Elders.Pandora
 
     public class ApplicationContext : IPandoraContext
     {
-        public ApplicationContext(string applicationName, string cluster = null, string machine = null)
+        public ApplicationContext(string applicationName = null, string cluster = null, string machine = null)
         {
-            this.ApplicationName = applicationName;
-            this.Cluster = cluster ?? Environment.GetEnvironmentVariable(EnvVar.ClusterKey) ?? Environment.GetEnvironmentVariable(EnvVar.ClusterKey, EnvironmentVariableTarget.Machine);
-            this.Machine = machine ?? Environment.GetEnvironmentVariable(EnvVar.MachineKey) ?? Environment.GetEnvironmentVariable(EnvVar.MachineKey, EnvironmentVariableTarget.Machine);
+            this.ApplicationName = applicationName ?? EnvVar.GetApplication();
+            this.Cluster = cluster ?? EnvVar.GetCluster();
+            this.Machine = machine ?? EnvVar.GetMachine();
         }
 
         public string ApplicationName { get; private set; }
@@ -35,10 +30,10 @@ namespace Elders.Pandora
 
     public class ClusterContext : IPandoraContext
     {
-        public ClusterContext(string applicationName, string cluster = null)
+        public ClusterContext(string applicationName = null, string cluster = null)
         {
-            this.ApplicationName = applicationName;
-            this.Cluster = cluster ?? Environment.GetEnvironmentVariable(EnvVar.ClusterKey) ?? Environment.GetEnvironmentVariable(EnvVar.ClusterKey, EnvironmentVariableTarget.Machine);
+            this.ApplicationName = applicationName ?? EnvVar.GetApplication();
+            this.Cluster = cluster ?? EnvVar.GetCluster();
             this.Machine = Box.Machine.NotSpecified;
         }
 

--- a/src/Elders.Pandora/Elders.Pandora.csproj
+++ b/src/Elders.Pandora/Elders.Pandora.csproj
@@ -22,40 +22,20 @@
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <DefineConstants>TRACE;DEBUG;NETSTANDARD2_0;</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+  <PropertyGroup>
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <EmbedSources>true</EmbedSources>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <DebugType>portable</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-    <EmbedSources>true</EmbedSources>
+    <AutoGenerateBindingRedirects>False</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration">
-      <Version>2.1.1</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="Microsoft.Extensions.Configuration">
-      <Version>2.1.1</Version>
-    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Elders.Pandora/EnvVar.cs
+++ b/src/Elders.Pandora/EnvVar.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+namespace Elders.Pandora
+{
+    public static class EnvVar
+    {
+        public const string ClusterOldKey = "CLUSTER_NAME";
+        public const string MachineOldKey = "COMPUTERNAME";
+
+        public const string ClusterKey = "pandora_cluster";
+        public const string ApplicationKey = "pandora_application";
+        public const string MachineKey = "pandora_machine";
+
+
+        /// <summary>
+        /// Gets the application name stored in <see cref="ApplicationKey"/> environment variable
+        /// </summary>
+        /// <returns>Returns the application name</returns>
+        public static string GetApplication()
+        {
+            return GetEnvironmentVariable(ApplicationKey);
+        }
+
+        /// <summary>
+        /// Gets the cluster stored in <see cref="ClusterKey"/> or <see cref="ClusterOldKey"/> environment variable
+        /// </summary>
+        /// <returns>Returns the clsuter name</returns>
+        public static string GetCluster()
+        {
+            return GetEnvironmentVariable(ClusterKey, ClusterOldKey);
+        }
+
+        /// <summary>
+        /// Gets the machine/node name stored in <see cref="MachineKey"/> or <see cref="MachineOldKey"/> environment variable
+        /// </summary>
+        /// <returns>Returns the clsuter name</returns>
+        public static string GetMachine()
+        {
+            return GetEnvironmentVariable(MachineKey, MachineOldKey);
+        }
+
+        public static string GetEnvironmentVariable(string key, string fallback)
+        {
+            return GetEnvironmentVariable(key) ?? GetEnvironmentVariable(fallback);
+        }
+
+        public static string GetEnvironmentVariable(string key)
+        {
+            return Environment.GetEnvironmentVariable(key) ?? Environment.GetEnvironmentVariable(key, EnvironmentVariableTarget.Machine);
+        }
+    }
+}

--- a/src/Elders.Pandora/Pandora.cs
+++ b/src/Elders.Pandora/Pandora.cs
@@ -144,9 +144,9 @@ namespace Elders.Pandora
         public IEnumerable<DeployedSetting> GetAll(IPandoraContext context)
         {
             return from setting in cfgRepo.GetAll()
-                   where setting.Key.Cluster == context.Cluster &&
-                         setting.Key.Machine == context.Machine &&
-                         setting.Key.ApplicationName == context.ApplicationName
+                   where setting.Key.Cluster.Equals(context.Cluster, StringComparison.OrdinalIgnoreCase) &&
+                         setting.Key.Machine.Equals(context.Machine, StringComparison.OrdinalIgnoreCase) &&
+                         setting.Key.ApplicationName.Equals(context.ApplicationName, StringComparison.OrdinalIgnoreCase)
                    select setting;
         }
 

--- a/src/Elders.Pandora/Pandora.cs
+++ b/src/Elders.Pandora/Pandora.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Elders.Pandora.Box;
 using Newtonsoft.Json;
-using System.ComponentModel;
 
 namespace Elders.Pandora
 {
@@ -141,12 +141,12 @@ namespace Elders.Pandora
             return cfgRepo.GetAll();
         }
 
-        public IEnumerable<DeployedSetting> GetAll(ApplicationContext applicationContext)
+        public IEnumerable<DeployedSetting> GetAll(IPandoraContext context)
         {
             return from setting in cfgRepo.GetAll()
-                   where setting.Key.Cluster == applicationContext.Cluster &&
-                         setting.Key.Machine == applicationContext.Machine &&
-                         setting.Key.ApplicationName == applicationContext.ApplicationName
+                   where setting.Key.Cluster == context.Cluster &&
+                         setting.Key.Machine == context.Machine &&
+                         setting.Key.ApplicationName == context.ApplicationName
                    select setting;
         }
 
@@ -155,9 +155,9 @@ namespace Elders.Pandora
             Set(settingKey, value, context);
         }
 
-        public void Set(string settingKey, string value, IPandoraContext applicationContex)
+        public void Set(string settingKey, string value, IPandoraContext context)
         {
-            var settingName = NameBuilder.GetSettingName(applicationContex.ApplicationName, applicationContex.Cluster, applicationContex.Machine, settingKey);
+            var settingName = NameBuilder.GetSettingName(context.ApplicationName, context.Cluster, context.Machine, settingKey);
             cfgRepo.Set(settingName, value);
         }
 
@@ -166,9 +166,9 @@ namespace Elders.Pandora
             Delete(settingKey, context);
         }
 
-        public void Delete(string settingKey, IPandoraContext applicationContex)
+        public void Delete(string settingKey, IPandoraContext context)
         {
-            var settingName = NameBuilder.GetSettingName(applicationContex.ApplicationName, applicationContex.Cluster, applicationContex.Machine, settingKey);
+            var settingName = NameBuilder.GetSettingName(context.ApplicationName, context.Cluster, context.Machine, settingKey);
             cfgRepo.Delete(settingName);
         }
     }

--- a/src/Elders.Pandora/Pandora.rn.md
+++ b/src/Elders.Pandora/Pandora.rn.md
@@ -1,3 +1,7 @@
+#### 1.0.0-beta0007 - 02.10.2018
+* Introduces new environment variables: `pandora_cluster`, `pandora_application`, `pandora_machine`. The old environment variables `CLUSTER_NAME` and `COMPUTERNAME` are still valid
+* PandoraConfigurationProvider now loads only the settings relevant to the provided context instead of all settings because you may have multiple application running side by side
+
 #### 1.0.0-beta0006 - 21.09.2018
 * Adds PandoraConfigurationProvider
 

--- a/src/Elders.Pandora/PandoraConfigurationProvider.cs
+++ b/src/Elders.Pandora/PandoraConfigurationProvider.cs
@@ -14,7 +14,7 @@ namespace Elders.Pandora
 
         public override void Load()
         {
-            Data = pandora.GetAll().ToDictionary(key => key.Key.SettingKey, value => value.Value);
+            Data = pandora.GetAll(pandora.ApplicationContext).ToDictionary(key => key.Key.SettingKey, value => value.Value);
         }
     }
 }


### PR DESCRIPTION
* Introduces new environment variables: `pandora_cluster`, `pandora_application`, `pandora_machine`. The old environment variables `CLUSTER_NAME` and `COMPUTERNAME` are still valid
* PandoraConfigurationProvider now loads only the settings relevant to the provided context instead of all settings because you may have multiple application running side by side